### PR TITLE
add flag for mongodb auth

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,7 @@ class st2(
   $db_password              = undef,
   $mongodb_version          = undef,
   $mongodb_manage_repo      = true,
+  $mongodb_auth             = true,
   $ng_init                  = true,
   $datastore_keys_dir       = $::st2::params::datstore_keys_dir,
   $datastore_key_path       = "${::st2::params::datstore_keys_dir}/datastore_key.json",

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -24,6 +24,7 @@
 #  include st2::profile::mongodb
 #
 class st2::profile::mongodb (
+  $db_auth     = $st2::mongodb_auth,
   $db_name     = $st2::db_name,
   $db_username = $st2::db_username,
   $db_password = $st2::db_password,
@@ -59,7 +60,7 @@ class st2::profile::mongodb (
     class { '::mongodb::client': }
 
     class { '::mongodb::server':
-      auth           => true,
+      auth           => $db_auth,
       port           => $db_port,
       create_admin   => true,
       store_creds    => true,


### PR DESCRIPTION
Default behavior is unchanged. This should be useful for getting around
the auth bugs that exist in the puppetlabs-mongodb module