### PR TITLE
don't set enable => false on sudo class

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -37,8 +37,6 @@ define st2::user(
       class { '::sudo':
         # do not purge files in /etc/sudoers.d/*
         purge               => false,
-        # the 'enable' option (for some reason) purges all /etc/sudoers.d/* files
-        enable              => false,
         # do not replace /etc/sudoers file
         config_file_replace => false,
       }


### PR DESCRIPTION
This causes the sudo module to try to set ensure => absent on a number of resources, including the /etc/sudoers.d directory. This fails with the following notice:
Notice: /Stage[main]/Sudo/File[/etc/sudoers.d/]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Sudo/File[/etc/sudoers.d/]/ensure: removed