### PR TITLE
Add parameter allowing control over nodejs repo url suffix

### DIFF
--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -15,7 +15,9 @@
 #
 #  include st2::profile::nodejs
 #
-class st2::profile::nodejs {
+class st2::profile::nodejs (
+  $repo_url_suffix = '4.x',
+) {
   if $::osfamily == 'RedHat' {
     # Red Hat 7.x + already have NodeJS 6.x+ installed
     # trying to install from nodesource repos fails, so just use the builtin
@@ -34,15 +36,15 @@ class st2::profile::nodejs {
     # to avoid their verification checks (ugh...).
     else {
       class { '::nodejs':
-        repo_url_suffix => '4.x',
         repo_class      => 'nodejs::repo::nodesource',
+        repo_url_suffix => $repo_url_suffix,
       }
     }
   }
   else {
     # else install nodejs 4.x from nodesource repo
     class { '::nodejs':
-      repo_url_suffix => '4.x',
+      repo_url_suffix => $repo_url_suffix,
     }
   }
 }


### PR DESCRIPTION
Default value is 4.x, which was the previous hard-coded value.

The latest versions of the st2chatops package require nodejs 6, so
this hard-coded repo suffix causes those package installations to fail.