### PR TITLE
fixes for mongodb profile

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -144,7 +144,7 @@ class st2::params(
   ## MongoDB Data
   $mongodb_admin_username = 'admin'
 
-  $mongodb_port = '27017'
+  $mongodb_port = 27017
   $mongodb_bind_ips = ['127.0.0.1']
 
   $mongodb_st2_db = 'st2'

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -105,10 +105,6 @@ class st2::profile::mongodb (
           tag    => 'st2::mongodb::debian',
         }
 
-        File <| title == '/var/lib/mongodb' |> {
-          recurse => true,
-          tag     => 'st2::mongodb::debian',
-        }
         Package<| tag == 'mongodb' |>
         -> File<| tag == 'st2::mongodb::debian' |>
         -> Service['mongodb']


### PR DESCRIPTION
Later versions of the of `puppet-mongodb` module check that the port is an integer. The default value set in `params.pp` is a string and causes compilation to fail unless changed.

When the `mongodb` service starts, several new files are created with mode `0644`, which is fine. The `/var/lib/mongodb` resource is a directory with mode `0755`, which is also fine. But setting `recurse => true` on the `/var/lib/mongodb` resource causes Puppet to change permissions for all files and subdirectories to `0755`. That wouldn't be a huge deal if that didn't also trigger a `mongodb` service restart... which generates new files with `0644` and causes another service restart on the next Puppet run, and so on.

Fortunately, the file permission changes are no longer needed due to updates to the `puppet-mongodb` module, as described in https://github.com/voxpupuli/puppet-mongodb/pull/349. I've confirmed that with testing, as well.

